### PR TITLE
…

### DIFF
--- a/src/Index/index.css
+++ b/src/Index/index.css
@@ -69,6 +69,7 @@ ul,li, ul label {
 
 #index{
     margin:-4px;
+    zoom:.3;
 }
 
 .CodeMirror {


### PR DESCRIPTION
Zoom out: Issue: the tool uses too much screen space and is distracting. Root cause: during one of the demos, I had to remove farther view so that it is easier for demo. Fix: Intrudce the zoom look back. Reason: helps to not see the minor flaws and work on problem solving